### PR TITLE
Fix zero divisor error when hovering on a medical state node

### DIFF
--- a/XEH_postInit.sqf
+++ b/XEH_postInit.sqf
@@ -44,7 +44,7 @@
 			[],
 			[0,0,0],
 			10,
-			[],
+			nil,
 			{
 				params ["_target", "_player", "_params", "_actionData"];
 				if(!GVAR(Stable_ShowCount)) exitWith {};
@@ -69,7 +69,7 @@
 			[],
 			[0,0,0],
 			10,
-			[],
+			nil,
 			{
 				params ["_target", "_player", "_params", "_actionData"];
 				if(!GVAR(Unstable_ShowCount)) exitWith {};
@@ -94,7 +94,7 @@
 			[],
 			[0,0,0],
 			10,
-			[],
+			nil,
 			{
 				params ["_target", "_player", "_params", "_actionData"];
 				if(!GVAR(Incapacitated_ShowCount)) exitWith {};


### PR DESCRIPTION
This PR fixes a zero divisor script error when opening Stable, Unstable, or Incapacitated.

```
Error in expression <menu_selectedAction select 0) select 9) select 3;
   private _runOnHove>
  Error position: <select 3;
   private _runOnHove>
  Error Zero divisor
File /z/ace/addons/interact_menu/functions/fnc_render.sqf..., line 82
```

![20220312171532_1](https://user-images.githubusercontent.com/204475/158038916-904a2823-0c3e-4d4f-91ba-d54a6e43cf4f.jpg).